### PR TITLE
Sanitize generated page content

### DIFF
--- a/frontend/GeneratedView.tsx
+++ b/frontend/GeneratedView.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { PageEndpoint } from 'Frontend/generated/endpoints.js';
+import DOMPurify from 'dompurify';
 
 export default function GeneratedView() {
   const { slug } = useParams();
@@ -14,7 +15,10 @@ export default function GeneratedView() {
 useEffect(() => {
   if (page?.styleContent) {
     const style = document.createElement('style');
-    style.innerHTML = page.styleContent;
+    style.textContent = DOMPurify.sanitize(page.styleContent, {
+      ALLOWED_TAGS: [],
+      ALLOWED_ATTR: [],
+    });
     document.head.appendChild(style);
     return () => {
       document.head.removeChild(style);
@@ -26,7 +30,10 @@ useEffect(() => {
 useEffect(() => {
   if (page?.scriptContent) {
     const script = document.createElement('script');
-    script.innerHTML = page.scriptContent;
+    script.textContent = DOMPurify.sanitize(page.scriptContent, {
+      ALLOWED_TAGS: [],
+      ALLOWED_ATTR: [],
+    });
     document.body.appendChild(script);
     return () => {
       document.body.removeChild(script);
@@ -41,7 +48,9 @@ useEffect(() => {
       {page.base64Image && (
         <img src={`data:image/png;base64,${page.base64Image}`} alt="Uploaded" style={{ maxWidth: '100%' }} />
       )}
-      <div dangerouslySetInnerHTML={{ __html: page.htmlContent }} />
+      <div
+        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(page.htmlContent) }}
+      />
     </div>
   ) : (
     <p>Loading…</p>

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "lit": "3.1.4",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "react-router-dom": "6.23.1"
+    "react-router-dom": "6.23.1",
+    "dompurify": "3.0.8"
   },
   "devDependencies": {
     "@babel/preset-react": "7.24.7",


### PR DESCRIPTION
## Summary
- add dompurify dependency
- sanitize HTML, CSS and JS strings in `GeneratedView`

## Testing
- `npm install dompurify --save` *(fails: forbidden due to lack of internet)*
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb355e220832fb3c7c41863c92d7d